### PR TITLE
Specify own api location

### DIFF
--- a/client/src/main/java/com/sendwithus/SendWithUs.java
+++ b/client/src/main/java/com/sendwithus/SendWithUs.java
@@ -23,29 +23,28 @@ import com.sendwithus.model.*;
  */
 public class SendWithUs
 {
-    
-    public static final String API_PROTO = "https";
-    public static final String API_HOST = "api.sendwithus.com";
-    public static final String API_PORT = "443";
-    
-    public static final String API_VERSION = "1";
     public static final String CLIENT_VERSION = "1.10.0";
     public static final String CLIENT_LANG = "java";
     public static final String SWU_API_HEADER = "X-SWU-API-KEY";
     public static final String SWU_CLIENT_HEADER = "X-SWU-API-CLIENT";
 
     private String apiKey;
+    private SendWithUsApiLocation sendWithUsApiLocation;
 
     public SendWithUs(String apiKey)
     {
+        this(apiKey, SendWithUsApiLocation.defaultApiLocation());
+    }
+
+    public SendWithUs(String apiKey, SendWithUsApiLocation sendWithUsApiLocation)
+    {
         this.apiKey = apiKey;
+        this.sendWithUsApiLocation = sendWithUsApiLocation;
     }
 
     private String getURLEndpoint(String resourceName)
     {
-        return String.format("%s://%s:%s/api/v%s/%s", SendWithUs.API_PROTO,
-                SendWithUs.API_HOST, SendWithUs.API_PORT,
-                SendWithUs.API_VERSION, resourceName);
+        return sendWithUsApiLocation.getEndpointUrl(resourceName);
     }
 
     private HttpURLConnection createConnection(

--- a/client/src/main/java/com/sendwithus/SendWithUsApiLocation.java
+++ b/client/src/main/java/com/sendwithus/SendWithUsApiLocation.java
@@ -1,0 +1,26 @@
+package com.sendwithus;
+
+public class SendWithUsApiLocation
+{
+    public static final String PROTO = "https";
+    public static final String HOST = "api.sendwithus.com";
+    public static final String PORT = "443";
+    public static final String VERSION = "1";
+
+    private final String apiLocation;
+
+    public SendWithUsApiLocation(String apiLocation)
+    {
+        this.apiLocation = apiLocation;
+    }
+
+    public String getEndpointUrl(String resourceName)
+    {
+        return String.format("%s/%s", apiLocation, resourceName);
+    }
+
+    public static SendWithUsApiLocation defaultApiLocation()
+    {
+        return new SendWithUsApiLocation(String.format("%s://%s:%s/api/v%s", PROTO, HOST, PORT, VERSION));
+    }
+}

--- a/client/src/test/java/com/sendwithus/SendWithUsTest.java
+++ b/client/src/test/java/com/sendwithus/SendWithUsTest.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.sendwithus.model.*;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,17 +26,17 @@ public class SendWithUsTest
     public static final String TEMPLATE_ID = "test_template_1";
     public static final String VERSION_ID = "test_version_1";
 
-    static SendWithUs sendwithusAPI;
+    SendWithUs sendwithusAPI;
 
-    static Map<String, Object> defaultRecipientParams = new HashMap<String, Object>();
-    static Map<String, Object> invalidRecipientParams = new HashMap<String, Object>();
-    static Map<String, Object> defaultSenderParams = new HashMap<String, Object>();
-    static Map<String, Object> defaultDataParams = new HashMap<String, Object>();
+    Map<String, Object> defaultRecipientParams = new HashMap<String, Object>();
+    Map<String, Object> invalidRecipientParams = new HashMap<String, Object>();
+    Map<String, Object> defaultSenderParams = new HashMap<String, Object>();
+    Map<String, Object> defaultDataParams = new HashMap<String, Object>();
     
     private static final String TEST_RECIPIENT_ADDRESS = "swunit+javaclient@sendwithus.com";
 
-    @BeforeClass
-    public static void setUp()
+    @Before
+    public void setUp()
     {
         sendwithusAPI = Mockito.spy(new SendWithUs(SENDWITHUS_API_KEY));
 
@@ -576,5 +576,32 @@ public class SendWithUsTest
         DeactivatedDrips receipt = sendwithusAPI.deactivateDrips(TEST_RECIPIENT_ADDRESS);
         assertSuccessfulAPIResponse(receipt);
     }
-   
+
+    /**
+     * Test default api location.
+     */
+    @Test
+    public void testDefaultApiLocation() throws Exception
+    {
+        sendwithusAPI.templates();
+
+        String url = String.format("%s://%s:%s/api/v%s/%s", SendWithUsApiLocation.PROTO, SendWithUsApiLocation.HOST, SendWithUsApiLocation.PORT, SendWithUsApiLocation.VERSION, "templates");
+        Mockito.verify(sendwithusAPI).makeURLRequest(url, "GET", null);
+    }
+
+    /**
+     * Test custom api location.
+     */
+    @Test
+    public void testCustomApiLocation() throws Exception
+    {
+        String apiLocation = "http://localhost:8888/v1";
+        SendWithUs sendwithusAPI = Mockito.spy(new SendWithUs(SENDWITHUS_API_KEY, new SendWithUsApiLocation(apiLocation)));
+        String url = String.format("%s/%s", apiLocation, "templates");
+        Mockito.doReturn("[]").when(sendwithusAPI).makeURLRequest(url, "GET", null);
+
+        sendwithusAPI.templates();
+
+        Mockito.verify(sendwithusAPI).makeURLRequest(url, "GET", null);
+    }
 }


### PR DESCRIPTION
This change allows to specify own api location so it's possible to mock the Sendwithus API with custom URL in tests.