### PR TITLE
Add CODEOWNERS and SUPPORT files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Auto tag Sendwithus employees on new Issues/Pull Requests
+*	@demoore @FlipCodes @Bean0B

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,3 @@
+Please only file issues that you believe represent actual bugs or feature requests for this API client.
+
+If you are having issues with your Sendwithus integration, have questions about email, or have found a bug with Sendwithus’ API please reach out to support@sendwithus.com and our support team will be happy to help.


### PR DESCRIPTION
This is a purely administrative PR to help users get better support as well as auto-tag Sendwithus employees when an issue/PR is created.