### PR TITLE
Add resend method and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Two APIs now exist for issuing "Send" requests:
  - createSnippet(String, String)
  - updateSnippet(String, String, String)
  - deleteSnippet(String)
+ - resend(String)
 
 ### Examples
 
@@ -148,6 +149,9 @@ SendWithUsSendRequest request = new SendWithUsSendRequest()
     .setAttachmentPaths(attachments)
     .setEspAccount(espAccount);
 SendReceipt sendReceipt = sendwithusAPI.send(request);
+
+// Resend Example
+SendReceipt sendReceipt = sendwithusAPI.resend("log_asdf123456qwerty"); 
 
 // Templates
 Email template = sendwithusAPI.template(TEMPLATE_ID);

--- a/client/src/main/java/com/sendwithus/SendWithUs.java
+++ b/client/src/main/java/com/sendwithus/SendWithUs.java
@@ -683,6 +683,24 @@ public class SendWithUs
         return gson.fromJson(response, CustomerReceipt.class);
     }
 
+    /**
+     * Resend a specific email by id.
+     *
+     * @param logId
+     *            The log id of the email to be resent
+     * @return The receipt ID
+     * @throws SendWithUsException
+     */
+    public SendReceipt resend(String logId) throws SendWithUsException {
+        Map<String, Object> sendParams = new HashMap<String, Object>();
+        sendParams.put("log_id", logId);
+
+        String url = getURLEndpoint("resend");
+
+        String response = makeURLRequest(url, "POST", sendParams);
+        Gson gson = new Gson();
+        return gson.fromJson(response, SendReceipt.class);
+    }
 
     /**
      * Gets all snippets for your account.

--- a/client/src/test/java/com/sendwithus/SendWithUsTest.java
+++ b/client/src/test/java/com/sendwithus/SendWithUsTest.java
@@ -198,6 +198,31 @@ public class SendWithUsTest
     }
 
     /**
+     * Test resend on simple message
+     */
+    @Test
+    public void testResend() throws SendWithUsException
+    {
+        SendReceipt sendReceipt = sendwithusAPI.send(EMAIL_ID,
+                defaultRecipientParams, defaultDataParams);
+
+        sendReceipt = sendwithusAPI.resend(sendReceipt.getReceiptID());
+
+        assertSuccessfulAPIReceipt(sendReceipt);
+        assertNotNull(sendReceipt.getEmail());
+        assertEquals(sendReceipt.getEmail().getLocale(), "en-US");
+    }
+
+    /**
+     * Test resend on invalid receipt_id
+     */
+    @Test(expected = SendWithUsException.class)
+    public void testResendOnInvalidId() throws SendWithUsException
+    {
+        SendReceipt sendReceipt = sendwithusAPI.resend("INVALID_RECEIPT_ID");
+    }
+
+    /**
      * Test send with sender info
      */
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added the ability to call the resend endpoint via the Java API

## Motivation and Context
I need to resend an email programmatically and not want to have to use the rest point directly 

## How Has This Been Tested?
See changes in the SendWithUsTest

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
