### PR TITLE
Fix serialization of POST/PUT parameters

### DIFF
--- a/client/src/main/java/com/sendwithus/SendWithUs.java
+++ b/client/src/main/java/com/sendwithus/SendWithUs.java
@@ -72,7 +72,7 @@ public class SendWithUs
 
         connection.setRequestMethod(method);
 
-        if (method == "POST")
+        if (method.equals("POST") || method.equals("PUT"))
         {
             connection.setDoOutput(true); // Note: this implicitly sets method
                                           // to POST


### PR DESCRIPTION
Parameters of POST and PUT API requests were not included in request
body because of direct string comparison (method == "POST") and missing
"PUT" case in that check.

For example, I could not use the snippets API to update or create a
snippet because I was receiving 400 Bad Request (empty JSON body).
